### PR TITLE
feat: add whatsapp scheduling bot

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -1,0 +1,30 @@
+# Zappoint WhatsApp Bot
+
+Bot de WhatsApp utilizando [whatsapp-web.js](https://github.com/pedroslopez/whatsapp-web.js) para realizar agendamentos.
+
+## Requisitos
+- Node.js 18+
+- Dependências definidas em `package.json`
+- Backend disponível e acessível via variável de ambiente `API_BASE_URL`
+
+## Configuração
+1. Atualize o número autorizado em `config.js` (somente dígitos, formato internacional).
+2. Instale as dependências:
+   ```bash
+   npm install
+   ```
+3. Defina a URL do backend, se necessário:
+   ```bash
+   export API_BASE_URL="http://localhost:3000"
+   ```
+
+## Uso
+1. Inicie o bot:
+   ```bash
+   npm start
+   ```
+2. Escaneie o QR Code exibido no terminal com o WhatsApp usando o número autorizado.
+
+O bot ignora mensagens de grupos e responde apenas ao número configurado.
+
+O fluxo de conversas cobre cadastro, agendamento, confirmação, cancelamento e listagem de agendamentos.

--- a/bot/config.js
+++ b/bot/config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  apiBaseUrl: process.env.API_BASE_URL || 'http://localhost:3000',
+  // Update with the phone numbers (digits only) that the bot should respond to
+  allowedNumbers: [
+    process.env.ALLOWED_NUMBER || '5511999999999'
+  ]
+};

--- a/bot/flows/appointment.js
+++ b/bot/flows/appointment.js
@@ -1,0 +1,101 @@
+const axios = require('axios');
+const { apiBaseUrl } = require('../config');
+const { menuText, serviceText } = require('../utils/messages');
+
+module.exports = {
+  service: async (session, msg, text) => {
+    const services = { '1': 'Cabelo', '2': 'Barba', '3': 'Cabelo e Barba' };
+    if (!services[text]) {
+      await msg.reply('Opção inválida.');
+      return;
+    }
+    session.service = services[text];
+    const profResp = await axios.get(`${apiBaseUrl}/professionals`);
+    session.professionals = profResp.data || [];
+    if (session.professionals.length === 0) {
+      await msg.reply('Nenhum profissional disponível.');
+      session.step = 'mainMenu';
+      await msg.reply(menuText());
+      return;
+    }
+    session.step = 'professional';
+    let profText = 'Com qual profissional?\n';
+    session.professionals.forEach((p, i) => {
+      profText += `${i + 1} - ${p.name}\n`;
+    });
+    await msg.reply(profText.trim());
+  },
+
+  professional: async (session, msg, text) => {
+    const idx = parseInt(text) - 1;
+    if (isNaN(idx) || idx < 0 || idx >= session.professionals.length) {
+      await msg.reply('Opção inválida.');
+      return;
+    }
+    session.professional = session.professionals[idx];
+    const dateResp = await axios.get(`${apiBaseUrl}/professionals/${session.professional.id}/available-dates`);
+    session.dates = dateResp.data || [];
+    if (session.dates.length === 0) {
+      await msg.reply('Nenhuma data disponível.');
+      session.step = 'mainMenu';
+      await msg.reply(menuText());
+      return;
+    }
+    session.step = 'date';
+    let dateText = 'Qual o melhor dia para você?\n';
+    session.dates.forEach((d, i) => { dateText += `${i + 1} - ${d}\n`; });
+    await msg.reply(dateText.trim());
+  },
+
+  date: async (session, msg, text) => {
+    const dIdx = parseInt(text) - 1;
+    if (isNaN(dIdx) || dIdx < 0 || dIdx >= session.dates.length) {
+      await msg.reply('Opção inválida.');
+      return;
+    }
+    session.date = session.dates[dIdx];
+    const timeResp = await axios.get(`${apiBaseUrl}/professionals/${session.professional.id}/available-times`, { params: { date: session.date } });
+    session.times = timeResp.data || [];
+    if (session.times.length === 0) {
+      await msg.reply('Nenhum horário disponível.');
+      session.step = 'mainMenu';
+      await msg.reply(menuText());
+      return;
+    }
+    session.step = 'time';
+    let timeText = 'De acordo com os horários disponíveis, escolha um abaixo:\n';
+    session.times.forEach((t, i) => { timeText += `${i + 1} - ${t}\n`; });
+    await msg.reply(timeText.trim());
+  },
+
+  time: async (session, msg, text) => {
+    const tIdx = parseInt(text) - 1;
+    if (isNaN(tIdx) || tIdx < 0 || tIdx >= session.times.length) {
+      await msg.reply('Opção inválida.');
+      return;
+    }
+    session.time = session.times[tIdx];
+    session.step = 'confirmAppointment';
+    await msg.reply(`Certo, agora confirme o agendamento:\n${session.service} com o profissional ${session.professional.name}, no dia ${session.date} às ${session.time}.\n\n1 - Confirmar\n2 - Cancelar e iniciar novamente`);
+  },
+
+  confirmAppointment: async (session, msg, text) => {
+    if (text === '1') {
+      await axios.post(`${apiBaseUrl}/appointments`, {
+        clientId: session.client.id,
+        professionalId: session.professional.id,
+        service: session.service,
+        date: session.date,
+        time: session.time
+      });
+      await msg.reply('Agendamento confirmado com sucesso! ✔');
+      session.step = 'mainMenu';
+      await msg.reply(menuText());
+    } else if (text === '2') {
+      session.step = 'service';
+      await msg.reply(serviceText());
+    } else {
+      await msg.reply('Opção inválida.');
+    }
+  }
+};

--- a/bot/flows/menu.js
+++ b/bot/flows/menu.js
@@ -1,0 +1,81 @@
+const axios = require('axios');
+const { apiBaseUrl } = require('../config');
+const { menuText, serviceText } = require('../utils/messages');
+
+module.exports = {
+  mainMenu: async (session, msg, text) => {
+    if (text === '1') {
+      session.step = 'service';
+      await msg.reply(serviceText());
+    } else if (text === '2') {
+      const resp = await axios.get(`${apiBaseUrl}/clients/${session.client.id}/appointments`, { params: { status: 'pending' } });
+      session.appointments = resp.data || [];
+      if (session.appointments.length === 0) {
+        await msg.reply('Você não possui agendamentos pendentes de confirmação.');
+        await msg.reply(menuText());
+      } else {
+        session.step = 'confirmExisting';
+        let textList = 'Qual agendamento deseja confirmar?\n';
+        session.appointments.forEach((a, i) => {
+          textList += `${i + 1} - ${a.service} com ${a.professionalName} em ${a.date} às ${a.time}\n`;
+        });
+        await msg.reply(textList.trim());
+      }
+    } else if (text === '3') {
+      const resp = await axios.get(`${apiBaseUrl}/clients/${session.client.id}/appointments`, { params: { status: 'scheduled' } });
+      session.appointments = resp.data || [];
+      if (session.appointments.length === 0) {
+        await msg.reply('Você não possui agendamentos para cancelar.');
+        await msg.reply(menuText());
+      } else {
+        session.step = 'cancelExisting';
+        let textList = 'Qual agendamento deseja cancelar?\n';
+        session.appointments.forEach((a, i) => {
+          textList += `${i + 1} - ${a.service} com ${a.professionalName} em ${a.date} às ${a.time}\n`;
+        });
+        await msg.reply(textList.trim());
+      }
+    } else if (text === '4') {
+      const resp = await axios.get(`${apiBaseUrl}/clients/${session.client.id}/appointments`, { params: { status: 'future' } });
+      const apps = resp.data || [];
+      if (apps.length === 0) {
+        await msg.reply('Você não possui agendamentos futuros.');
+      } else {
+        let list = 'Seus agendamentos:\n';
+        apps.forEach(a => {
+          list += `- ${a.service} com ${a.professionalName} em ${a.date} às ${a.time}\n`;
+        });
+        await msg.reply(list.trim());
+      }
+      await msg.reply(menuText());
+    } else {
+      await msg.reply('Opção inválida. Escolha uma das opções do menu.');
+    }
+  },
+
+  confirmExisting: async (session, msg, text) => {
+    const cIdx = parseInt(text) - 1;
+    if (isNaN(cIdx) || cIdx < 0 || cIdx >= session.appointments.length) {
+      await msg.reply('Opção inválida.');
+      return;
+    }
+    const app = session.appointments[cIdx];
+    await axios.patch(`${apiBaseUrl}/appointments/${app.id}/confirm`);
+    await msg.reply('Agendamento confirmado com sucesso!');
+    session.step = 'mainMenu';
+    await msg.reply(menuText());
+  },
+
+  cancelExisting: async (session, msg, text) => {
+    const xIdx = parseInt(text) - 1;
+    if (isNaN(xIdx) || xIdx < 0 || xIdx >= session.appointments.length) {
+      await msg.reply('Opção inválida.');
+      return;
+    }
+    const appToCancel = session.appointments[xIdx];
+    await axios.delete(`${apiBaseUrl}/appointments/${appToCancel.id}`);
+    await msg.reply('Agendamento cancelado.');
+    session.step = 'mainMenu';
+    await msg.reply(menuText());
+  }
+};

--- a/bot/flows/registration.js
+++ b/bot/flows/registration.js
@@ -1,0 +1,62 @@
+const axios = require('axios');
+const { apiBaseUrl } = require('../config');
+const { menuText } = require('../utils/messages');
+
+module.exports = {
+  start: async (session, msg, text) => {
+    if (text === '1') {
+      session.step = 'awaitExistingCPF';
+      await msg.reply('Certo, me informe seu CPF.');
+    } else if (text === '2') {
+      session.step = 'awaitCPF';
+      await msg.reply('Então vamos realizar o seu cadastro!\nSerá bem rápido.\nPrimeiro me passe o seu CPF.');
+    } else {
+      await msg.reply('Opção inválida. Responda com 1 ou 2.');
+    }
+  },
+
+  awaitExistingCPF: async (session, msg, text, sessions) => {
+    session.cpf = text.replace(/\D/g, '');
+    try {
+      const resp = await axios.get(`${apiBaseUrl}/clients?cpf=${session.cpf}`);
+      if (resp.data && resp.data.length > 0) {
+        session.client = resp.data[0];
+        session.step = 'mainMenu';
+        await msg.reply(menuText());
+      } else {
+        session.step = 'awaitCPF';
+        await msg.reply('Não encontrei seu cadastro, vamos realizar um novo.\nPrimeiro me passe o seu CPF.');
+      }
+    } catch (e) {
+      console.error(e);
+      await msg.reply('Erro ao verificar cadastro.');
+      delete sessions[msg.from];
+    }
+  },
+
+  awaitCPF: async (session, msg, text) => {
+    session.cpf = text.replace(/\D/g, '');
+    session.step = 'awaitName';
+    await msg.reply('Certo!! Agora preciso do seu primeiro e último nome.');
+  },
+
+  awaitName: async (session, msg, text, sessions) => {
+    const [firstName, ...rest] = text.split(' ');
+    const lastName = rest.join(' ');
+    try {
+      const existing = await axios.get(`${apiBaseUrl}/clients?cpf=${session.cpf}`);
+      if (!existing.data || existing.data.length === 0) {
+        const created = await axios.post(`${apiBaseUrl}/clients`, { cpf: session.cpf, firstName, lastName });
+        session.client = created.data;
+      } else {
+        session.client = existing.data[0];
+      }
+      session.step = 'mainMenu';
+      await msg.reply('Ok, pré-cadastro realizado com sucesso!\n' + menuText());
+    } catch (e) {
+      console.error(e);
+      await msg.reply('Não foi possível realizar o cadastro.');
+      delete sessions[msg.from];
+    }
+  }
+};

--- a/bot/index.js
+++ b/bot/index.js
@@ -1,0 +1,56 @@
+const { Client, LocalAuth } = require('whatsapp-web.js');
+const qrcode = require('qrcode-terminal');
+const { allowedNumbers } = require('./config');
+const registration = require('./flows/registration');
+const menu = require('./flows/menu');
+const appointment = require('./flows/appointment');
+
+const client = new Client({ authStrategy: new LocalAuth() });
+
+const sessions = {};
+const handlers = { ...registration, ...menu, ...appointment };
+
+client.on('qr', qr => {
+  qrcode.generate(qr, { small: true });
+});
+
+client.on('ready', () => {
+  console.log('Bot is ready!');
+});
+
+client.on('message', async msg => {
+  if (msg.from.endsWith('@g.us')) {
+    return;
+  }
+  const sender = msg.from.split('@')[0];
+  if (!allowedNumbers.includes(sender)) {
+    return;
+  }
+
+  const chatId = msg.from;
+  const text = msg.body.trim();
+
+  if (!sessions[chatId]) {
+    sessions[chatId] = { step: 'start' };
+    await msg.reply('Seja bem-vindo(a), esse número ainda não possui cadastro, você já é cliente?\n1 - Sim\n2 - Não');
+    return;
+  }
+
+  const session = sessions[chatId];
+  const handler = handlers[session.step];
+
+  try {
+    if (handler) {
+      await handler(session, msg, text, sessions);
+    } else {
+      await msg.reply('Não entendi. Vamos começar novamente.');
+      delete sessions[chatId];
+    }
+  } catch (err) {
+    console.error(err);
+    await msg.reply('Ocorreu um erro ao processar sua solicitação.');
+    delete sessions[chatId];
+  }
+});
+
+client.initialize();

--- a/bot/package.json
+++ b/bot/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "zappoint-bot",
+  "version": "1.0.0",
+  "description": "WhatsApp bot for appointment scheduling using whatsapp-web.js",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "echo \"No tests configured\" && exit 0"
+  },
+  "dependencies": {
+    "axios": "^1.6.2",
+    "qrcode-terminal": "^0.12.0",
+    "whatsapp-web.js": "^1.23.0"
+  }
+}

--- a/bot/utils/messages.js
+++ b/bot/utils/messages.js
@@ -1,0 +1,9 @@
+function menuText() {
+  return 'O que gostaria de fazer hoje?\n1 - Agendar horário\n2 - Confirmar agendamento\n3 - Cancelar agendamento\n4 - Conferir meus agendamentos';
+}
+
+function serviceText() {
+  return 'Qual serviço gostaria de agendar?\n1 - Cabelo\n2 - Barba\n3 - Cabelo e Barba';
+}
+
+module.exports = { menuText, serviceText };


### PR DESCRIPTION
## Summary
- add config file to limit bot responses to specific numbers and ignore group chats
- modularize conversation flow into registration, menu, and appointment handlers
- document configuration for authorized number and group message behavior

## Testing
- `node --check index.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aba6a023188321863524e198856ff8