### PR TITLE
feat: add back navigation and modular messages

### DIFF
--- a/bot/flows/appointment.js
+++ b/bot/flows/appointment.js
@@ -4,6 +4,11 @@ const { menuText, serviceText } = require('../utils/messages');
 
 module.exports = {
   service: async (session, msg, text) => {
+    if (text === '0' || text.toLowerCase() === 'voltar') {
+      session.step = 'mainMenu';
+      await msg.reply(menuText());
+      return;
+    }
     const services = { '1': 'Cabelo', '2': 'Barba', '3': 'Cabelo e Barba' };
     if (!services[text]) {
       await msg.reply('Opção inválida.');
@@ -23,10 +28,16 @@ module.exports = {
     session.professionals.forEach((p, i) => {
       profText += `${i + 1} - ${p.name}\n`;
     });
+    profText += '0 - Voltar';
     await msg.reply(profText.trim());
   },
 
   professional: async (session, msg, text) => {
+    if (text === '0' || text.toLowerCase() === 'voltar') {
+      session.step = 'service';
+      await msg.reply(serviceText());
+      return;
+    }
     const idx = parseInt(text) - 1;
     if (isNaN(idx) || idx < 0 || idx >= session.professionals.length) {
       await msg.reply('Opção inválida.');
@@ -44,10 +55,21 @@ module.exports = {
     session.step = 'date';
     let dateText = 'Qual o melhor dia para você?\n';
     session.dates.forEach((d, i) => { dateText += `${i + 1} - ${d}\n`; });
+    dateText += '0 - Voltar';
     await msg.reply(dateText.trim());
   },
 
   date: async (session, msg, text) => {
+    if (text === '0' || text.toLowerCase() === 'voltar') {
+      session.step = 'professional';
+      let profText = 'Com qual profissional?\n';
+      session.professionals.forEach((p, i) => {
+        profText += `${i + 1} - ${p.name}\n`;
+      });
+      profText += '0 - Voltar';
+      await msg.reply(profText.trim());
+      return;
+    }
     const dIdx = parseInt(text) - 1;
     if (isNaN(dIdx) || dIdx < 0 || dIdx >= session.dates.length) {
       await msg.reply('Opção inválida.');
@@ -65,10 +87,19 @@ module.exports = {
     session.step = 'time';
     let timeText = 'De acordo com os horários disponíveis, escolha um abaixo:\n';
     session.times.forEach((t, i) => { timeText += `${i + 1} - ${t}\n`; });
+    timeText += '0 - Voltar';
     await msg.reply(timeText.trim());
   },
 
   time: async (session, msg, text) => {
+    if (text === '0' || text.toLowerCase() === 'voltar') {
+      session.step = 'date';
+      let dateText = 'Qual o melhor dia para você?\n';
+      session.dates.forEach((d, i) => { dateText += `${i + 1} - ${d}\n`; });
+      dateText += '0 - Voltar';
+      await msg.reply(dateText.trim());
+      return;
+    }
     const tIdx = parseInt(text) - 1;
     if (isNaN(tIdx) || tIdx < 0 || tIdx >= session.times.length) {
       await msg.reply('Opção inválida.');
@@ -76,10 +107,18 @@ module.exports = {
     }
     session.time = session.times[tIdx];
     session.step = 'confirmAppointment';
-    await msg.reply(`Certo, agora confirme o agendamento:\n${session.service} com o profissional ${session.professional.name}, no dia ${session.date} às ${session.time}.\n\n1 - Confirmar\n2 - Cancelar e iniciar novamente`);
+    await msg.reply(`Certo, agora confirme o agendamento:\n${session.service} com o profissional ${session.professional.name}, no dia ${session.date} às ${session.time}.\n\n1 - Confirmar\n2 - Cancelar e iniciar novamente\n0 - Voltar`);
   },
 
   confirmAppointment: async (session, msg, text) => {
+    if (text === '0' || text.toLowerCase() === 'voltar') {
+      session.step = 'time';
+      let timeText = 'De acordo com os horários disponíveis, escolha um abaixo:\n';
+      session.times.forEach((t, i) => { timeText += `${i + 1} - ${t}\n`; });
+      timeText += '0 - Voltar';
+      await msg.reply(timeText.trim());
+      return;
+    }
     if (text === '1') {
       await axios.post(`${apiBaseUrl}/appointments`, {
         clientId: session.client.id,

--- a/bot/flows/menu.js
+++ b/bot/flows/menu.js
@@ -1,10 +1,13 @@
 const axios = require('axios');
 const { apiBaseUrl } = require('../config');
-const { menuText, serviceText } = require('../utils/messages');
+const { menuText, serviceText, startText } = require('../utils/messages');
 
 module.exports = {
   mainMenu: async (session, msg, text) => {
-    if (text === '1') {
+    if (text === '0' || text.toLowerCase() === 'voltar') {
+      session.step = 'start';
+      await msg.reply(startText());
+    } else if (text === '1') {
       session.step = 'service';
       await msg.reply(serviceText());
     } else if (text === '2') {
@@ -19,6 +22,7 @@ module.exports = {
         session.appointments.forEach((a, i) => {
           textList += `${i + 1} - ${a.service} com ${a.professionalName} em ${a.date} às ${a.time}\n`;
         });
+        textList += '0 - Voltar';
         await msg.reply(textList.trim());
       }
     } else if (text === '3') {
@@ -33,6 +37,7 @@ module.exports = {
         session.appointments.forEach((a, i) => {
           textList += `${i + 1} - ${a.service} com ${a.professionalName} em ${a.date} às ${a.time}\n`;
         });
+        textList += '0 - Voltar';
         await msg.reply(textList.trim());
       }
     } else if (text === '4') {
@@ -54,6 +59,11 @@ module.exports = {
   },
 
   confirmExisting: async (session, msg, text) => {
+    if (text === '0' || text.toLowerCase() === 'voltar') {
+      session.step = 'mainMenu';
+      await msg.reply(menuText());
+      return;
+    }
     const cIdx = parseInt(text) - 1;
     if (isNaN(cIdx) || cIdx < 0 || cIdx >= session.appointments.length) {
       await msg.reply('Opção inválida.');
@@ -67,6 +77,11 @@ module.exports = {
   },
 
   cancelExisting: async (session, msg, text) => {
+    if (text === '0' || text.toLowerCase() === 'voltar') {
+      session.step = 'mainMenu';
+      await msg.reply(menuText());
+      return;
+    }
     const xIdx = parseInt(text) - 1;
     if (isNaN(xIdx) || xIdx < 0 || xIdx >= session.appointments.length) {
       await msg.reply('Opção inválida.');

--- a/bot/flows/registration.js
+++ b/bot/flows/registration.js
@@ -1,21 +1,32 @@
 const axios = require('axios');
 const { apiBaseUrl } = require('../config');
-const { menuText } = require('../utils/messages');
+const {
+  menuText,
+  startText,
+  askCPFExistingText,
+  askCPFNewText,
+  askNameText
+} = require('../utils/messages');
 
 module.exports = {
   start: async (session, msg, text) => {
     if (text === '1') {
       session.step = 'awaitExistingCPF';
-      await msg.reply('Certo, me informe seu CPF.');
+      await msg.reply(askCPFExistingText());
     } else if (text === '2') {
       session.step = 'awaitCPF';
-      await msg.reply('Então vamos realizar o seu cadastro!\nSerá bem rápido.\nPrimeiro me passe o seu CPF.');
+      await msg.reply(askCPFNewText());
     } else {
       await msg.reply('Opção inválida. Responda com 1 ou 2.');
     }
   },
 
   awaitExistingCPF: async (session, msg, text, sessions) => {
+    if (text === '0' || text.toLowerCase() === 'voltar') {
+      session.step = 'start';
+      await msg.reply(startText());
+      return;
+    }
     session.cpf = text.replace(/\D/g, '');
     try {
       const resp = await axios.get(`${apiBaseUrl}/clients?cpf=${session.cpf}`);
@@ -25,7 +36,7 @@ module.exports = {
         await msg.reply(menuText());
       } else {
         session.step = 'awaitCPF';
-        await msg.reply('Não encontrei seu cadastro, vamos realizar um novo.\nPrimeiro me passe o seu CPF.');
+        await msg.reply('Não encontrei seu cadastro, vamos realizar um novo.\nPrimeiro me passe o seu CPF.\n0 - Voltar');
       }
     } catch (e) {
       console.error(e);
@@ -35,12 +46,22 @@ module.exports = {
   },
 
   awaitCPF: async (session, msg, text) => {
+    if (text === '0' || text.toLowerCase() === 'voltar') {
+      session.step = 'start';
+      await msg.reply(startText());
+      return;
+    }
     session.cpf = text.replace(/\D/g, '');
     session.step = 'awaitName';
-    await msg.reply('Certo!! Agora preciso do seu primeiro e último nome.');
+    await msg.reply(askNameText());
   },
 
   awaitName: async (session, msg, text, sessions) => {
+    if (text === '0' || text.toLowerCase() === 'voltar') {
+      session.step = 'awaitCPF';
+      await msg.reply(askCPFNewText());
+      return;
+    }
     const [firstName, ...rest] = text.split(' ');
     const lastName = rest.join(' ');
     try {

--- a/bot/index.js
+++ b/bot/index.js
@@ -1,14 +1,43 @@
 const { Client, LocalAuth } = require('whatsapp-web.js');
 const qrcode = require('qrcode-terminal');
 const { allowedNumbers } = require('./config');
-const registration = require('./flows/registration');
-const menu = require('./flows/menu');
-const appointment = require('./flows/appointment');
+const {
+  start,
+  awaitExistingCPF,
+  awaitCPF,
+  awaitName
+} = require('./flows/registration');
+const {
+  mainMenu,
+  confirmExisting,
+  cancelExisting
+} = require('./flows/menu');
+const {
+  service,
+  professional,
+  date,
+  time,
+  confirmAppointment
+} = require('./flows/appointment');
+const { startText } = require('./utils/messages');
 
 const client = new Client({ authStrategy: new LocalAuth() });
 
 const sessions = {};
-const handlers = { ...registration, ...menu, ...appointment };
+const handlers = {
+  start,
+  awaitExistingCPF,
+  awaitCPF,
+  awaitName,
+  mainMenu,
+  confirmExisting,
+  cancelExisting,
+  service,
+  professional,
+  date,
+  time,
+  confirmAppointment
+};
 
 client.on('qr', qr => {
   qrcode.generate(qr, { small: true });
@@ -32,7 +61,7 @@ client.on('message', async msg => {
 
   if (!sessions[chatId]) {
     sessions[chatId] = { step: 'start' };
-    await msg.reply('Seja bem-vindo(a), esse número ainda não possui cadastro, você já é cliente?\n1 - Sim\n2 - Não');
+    await msg.reply(startText());
     return;
   }
 

--- a/bot/utils/messages.js
+++ b/bot/utils/messages.js
@@ -1,9 +1,32 @@
+function startText() {
+  return 'Seja bem-vindo(a), esse número ainda não possui cadastro, você já é cliente?\n1 - Sim\n2 - Não';
+}
+
 function menuText() {
-  return 'O que gostaria de fazer hoje?\n1 - Agendar horário\n2 - Confirmar agendamento\n3 - Cancelar agendamento\n4 - Conferir meus agendamentos';
+  return 'O que gostaria de fazer hoje?\n1 - Agendar horário\n2 - Confirmar agendamento\n3 - Cancelar agendamento\n4 - Conferir meus agendamentos\n0 - Voltar';
 }
 
 function serviceText() {
-  return 'Qual serviço gostaria de agendar?\n1 - Cabelo\n2 - Barba\n3 - Cabelo e Barba';
+  return 'Qual serviço gostaria de agendar?\n1 - Cabelo\n2 - Barba\n3 - Cabelo e Barba\n0 - Voltar';
 }
 
-module.exports = { menuText, serviceText };
+function askCPFExistingText() {
+  return 'Certo, me informe seu CPF.\n0 - Voltar';
+}
+
+function askCPFNewText() {
+  return 'Então vamos realizar o seu cadastro!\nSerá bem rápido.\nPrimeiro me passe o seu CPF.\n0 - Voltar';
+}
+
+function askNameText() {
+  return 'Certo!! Agora preciso do seu primeiro e último nome.\n0 - Voltar';
+}
+
+module.exports = {
+  startText,
+  menuText,
+  serviceText,
+  askCPFExistingText,
+  askCPFNewText,
+  askNameText
+};


### PR DESCRIPTION
## Summary
- modularize prompts in `messages.js`
- enumerate handlers in `index.js` for clarity
- add `0`/`voltar` navigation to revisit previous steps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aba9efe4a483219058b5fd8db40b05