### PR TITLE
Integrate bot with backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bot/node_modules/

--- a/bot/config.js
+++ b/bot/config.js
@@ -1,5 +1,6 @@
 module.exports = {
   apiBaseUrl: process.env.API_BASE_URL || 'http://localhost:3000',
+  companyId: process.env.COMPANY_ID || '00000000-0000-0000-0000-000000000000',
   // Update with the phone numbers (digits only) that the bot should respond to
   allowedNumbers: [
     process.env.ALLOWED_NUMBER || '5511999999999'

--- a/bot/flows/appointment.js
+++ b/bot/flows/appointment.js
@@ -1,21 +1,42 @@
 const axios = require('axios');
-const { apiBaseUrl } = require('../config');
-const { menuText, serviceText } = require('../utils/messages');
+const { apiBaseUrl, companyId } = require('../config');
+const { menuText } = require('../utils/messages');
+
+function toIsoDate(dateStr) {
+  const [day, month, year] = dateStr.split('/');
+  return `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
+}
+
+async function listServices(session, msg) {
+  const resp = await axios.get(`${apiBaseUrl}/${companyId}/servico`);
+  session.services = resp.data || [];
+  if (session.services.length === 0) {
+    await msg.reply('Nenhum serviço disponível.');
+    session.step = 'mainMenu';
+    await msg.reply(menuText());
+    return;
+  }
+  let text = 'Qual serviço gostaria de agendar?\n';
+  session.services.forEach((s, i) => { text += `${i + 1} - ${s.descricao}\n`; });
+  text += '0 - Voltar';
+  await msg.reply(text.trim());
+}
 
 module.exports = {
+  listServices,
   service: async (session, msg, text) => {
     if (text === '0' || text.toLowerCase() === 'voltar') {
       session.step = 'mainMenu';
       await msg.reply(menuText());
       return;
     }
-    const services = { '1': 'Cabelo', '2': 'Barba', '3': 'Cabelo e Barba' };
-    if (!services[text]) {
+    const idx = parseInt(text) - 1;
+    if (isNaN(idx) || idx < 0 || idx >= session.services.length) {
       await msg.reply('Opção inválida.');
       return;
     }
-    session.service = services[text];
-    const profResp = await axios.get(`${apiBaseUrl}/professionals`);
+    session.service = session.services[idx];
+    const profResp = await axios.get(`${apiBaseUrl}/${companyId}/usuario`);
     session.professionals = profResp.data || [];
     if (session.professionals.length === 0) {
       await msg.reply('Nenhum profissional disponível.');
@@ -26,7 +47,7 @@ module.exports = {
     session.step = 'professional';
     let profText = 'Com qual profissional?\n';
     session.professionals.forEach((p, i) => {
-      profText += `${i + 1} - ${p.name}\n`;
+      profText += `${i + 1} - ${p.nomeInteiro}\n`;
     });
     profText += '0 - Voltar';
     await msg.reply(profText.trim());
@@ -35,7 +56,7 @@ module.exports = {
   professional: async (session, msg, text) => {
     if (text === '0' || text.toLowerCase() === 'voltar') {
       session.step = 'service';
-      await msg.reply(serviceText());
+      await listServices(session, msg);
       return;
     }
     const idx = parseInt(text) - 1;
@@ -44,40 +65,26 @@ module.exports = {
       return;
     }
     session.professional = session.professionals[idx];
-    const dateResp = await axios.get(`${apiBaseUrl}/professionals/${session.professional.id}/available-dates`);
-    session.dates = dateResp.data || [];
-    if (session.dates.length === 0) {
-      await msg.reply('Nenhuma data disponível.');
-      session.step = 'mainMenu';
-      await msg.reply(menuText());
-      return;
-    }
     session.step = 'date';
-    let dateText = 'Qual o melhor dia para você?\n';
-    session.dates.forEach((d, i) => { dateText += `${i + 1} - ${d}\n`; });
-    dateText += '0 - Voltar';
-    await msg.reply(dateText.trim());
+    await msg.reply('Qual o melhor dia para você? (DD/MM/AAAA)\n0 - Voltar');
   },
 
   date: async (session, msg, text) => {
     if (text === '0' || text.toLowerCase() === 'voltar') {
       session.step = 'professional';
       let profText = 'Com qual profissional?\n';
-      session.professionals.forEach((p, i) => {
-        profText += `${i + 1} - ${p.name}\n`;
-      });
+      session.professionals.forEach((p, i) => { profText += `${i + 1} - ${p.nomeInteiro}\n`; });
       profText += '0 - Voltar';
       await msg.reply(profText.trim());
       return;
     }
-    const dIdx = parseInt(text) - 1;
-    if (isNaN(dIdx) || dIdx < 0 || dIdx >= session.dates.length) {
-      await msg.reply('Opção inválida.');
-      return;
-    }
-    session.date = session.dates[dIdx];
-    const timeResp = await axios.get(`${apiBaseUrl}/professionals/${session.professional.id}/available-times`, { params: { date: session.date } });
-    session.times = timeResp.data || [];
+    session.date = text;
+    const resp = await axios.get(`${apiBaseUrl}/${companyId}/agendamento`);
+    const appointments = resp.data || [];
+    const day = toIsoDate(session.date);
+    const busy = appointments.filter(a => a.idUsuario === session.professional.id && a.dataHoraInicio.startsWith(day));
+    const allTimes = ['09:00', '10:00', '11:00', '12:00', '13:00', '14:00', '15:00', '16:00'];
+    session.times = allTimes.filter(t => !busy.some(b => b.dataHoraInicio.includes(t)));
     if (session.times.length === 0) {
       await msg.reply('Nenhum horário disponível.');
       session.step = 'mainMenu';
@@ -94,10 +101,7 @@ module.exports = {
   time: async (session, msg, text) => {
     if (text === '0' || text.toLowerCase() === 'voltar') {
       session.step = 'date';
-      let dateText = 'Qual o melhor dia para você?\n';
-      session.dates.forEach((d, i) => { dateText += `${i + 1} - ${d}\n`; });
-      dateText += '0 - Voltar';
-      await msg.reply(dateText.trim());
+      await msg.reply('Qual o melhor dia para você? (DD/MM/AAAA)\n0 - Voltar');
       return;
     }
     const tIdx = parseInt(text) - 1;
@@ -107,7 +111,7 @@ module.exports = {
     }
     session.time = session.times[tIdx];
     session.step = 'confirmAppointment';
-    await msg.reply(`Certo, agora confirme o agendamento:\n${session.service} com o profissional ${session.professional.name}, no dia ${session.date} às ${session.time}.\n\n1 - Confirmar\n2 - Cancelar e iniciar novamente\n0 - Voltar`);
+    await msg.reply(`Certo, agora confirme o agendamento:\n${session.service.descricao} com o profissional ${session.professional.nomeInteiro}, no dia ${session.date} às ${session.time}.\n\n1 - Confirmar\n2 - Cancelar e iniciar novamente\n0 - Voltar`);
   },
 
   confirmAppointment: async (session, msg, text) => {
@@ -120,19 +124,19 @@ module.exports = {
       return;
     }
     if (text === '1') {
-      await axios.post(`${apiBaseUrl}/appointments`, {
-        clientId: session.client.id,
-        professionalId: session.professional.id,
-        service: session.service,
-        date: session.date,
-        time: session.time
+      const dateISO = toIsoDate(session.date);
+      await axios.post(`${apiBaseUrl}/${companyId}/agendamento`, {
+        idCliente: session.client.id,
+        idUsuario: session.professional.id,
+        idServico: [session.service.id],
+        dataHoraInicio: `${dateISO}T${session.time}:00`
       });
       await msg.reply('Agendamento confirmado com sucesso! ✔');
       session.step = 'mainMenu';
       await msg.reply(menuText());
     } else if (text === '2') {
       session.step = 'service';
-      await msg.reply(serviceText());
+      await listServices(session, msg);
     } else {
       await msg.reply('Opção inválida.');
     }

--- a/bot/flows/menu.js
+++ b/bot/flows/menu.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 const { apiBaseUrl } = require('../config');
-const { menuText, serviceText, startText } = require('../utils/messages');
+const { menuText, startText } = require('../utils/messages');
+const { listServices } = require('./appointment');
 
 module.exports = {
   mainMenu: async (session, msg, text) => {
@@ -9,7 +10,7 @@ module.exports = {
       await msg.reply(startText());
     } else if (text === '1') {
       session.step = 'service';
-      await msg.reply(serviceText());
+      await listServices(session, msg);
     } else if (text === '2') {
       const resp = await axios.get(`${apiBaseUrl}/clients/${session.client.id}/appointments`, { params: { status: 'pending' } });
       session.appointments = resp.data || [];

--- a/bot/flows/registration.js
+++ b/bot/flows/registration.js
@@ -1,5 +1,5 @@
 const axios = require('axios');
-const { apiBaseUrl } = require('../config');
+const { apiBaseUrl, companyId } = require('../config');
 const {
   menuText,
   startText,
@@ -29,7 +29,7 @@ module.exports = {
     }
     session.cpf = text.replace(/\D/g, '');
     try {
-      const resp = await axios.get(`${apiBaseUrl}/clients?cpf=${session.cpf}`);
+      const resp = await axios.get(`${apiBaseUrl}/${companyId}/cliente?cpf=${session.cpf}`);
       if (resp.data && resp.data.length > 0) {
         session.client = resp.data[0];
         session.step = 'mainMenu';
@@ -65,9 +65,14 @@ module.exports = {
     const [firstName, ...rest] = text.split(' ');
     const lastName = rest.join(' ');
     try {
-      const existing = await axios.get(`${apiBaseUrl}/clients?cpf=${session.cpf}`);
+      const existing = await axios.get(`${apiBaseUrl}/${companyId}/cliente?cpf=${session.cpf}`);
       if (!existing.data || existing.data.length === 0) {
-        const created = await axios.post(`${apiBaseUrl}/clients`, { cpf: session.cpf, firstName, lastName });
+        const phone = msg.from.split('@')[0];
+        const created = await axios.post(`${apiBaseUrl}/${companyId}/cliente`, {
+          cpf: session.cpf,
+          nome: `${firstName} ${lastName}`,
+          telefone: phone
+        });
         session.client = created.data;
       } else {
         session.client = existing.data[0];


### PR DESCRIPTION
## Summary
- add company ID config for backend routing
- fetch services, professionals, and availability from backend when scheduling
- hook main menu and registration flow to backend endpoints

## Testing
- `cd bot && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6c19735f08321b62eb6702cb23247