### PR TITLE
Add client lookup by CPF and adjust API port

### DIFF
--- a/ZapAgenda-api-aspnet-main/controllers/ClienteController.cs
+++ b/ZapAgenda-api-aspnet-main/controllers/ClienteController.cs
@@ -17,6 +17,31 @@ namespace ZapAgenda_api_aspnet.controllers
         }
 
 
+        [HttpGet]
+        public async Task<IActionResult> Get([FromQuery] string? cpf, Guid IdEmpresa)
+        {
+            var empresa = await _empresaRepo.GetByGuidAsync(IdEmpresa);
+            if (empresa.IsFailed)
+            {
+                return NotFound(empresa.Errors);
+            }
+
+            if (string.IsNullOrWhiteSpace(cpf))
+            {
+                var clientes = await _clienteRepo.GetAllPorEmpresaAsync(IdEmpresa);
+                return Ok(clientes);
+            }
+
+            var cliente = await _clienteRepo.GetByCpfAsync(cpf, IdEmpresa);
+            if (cliente.IsFailed)
+            {
+                return BadRequest(cliente.Errors);
+            }
+
+            return Ok(new[] { cliente.Value });
+        }
+
+
         [HttpGet("{idCliente}")]
         public async Task<IActionResult> GetById([FromRoute] int idCliente, Guid IdEmpresa)
         {

--- a/ZapAgenda-api-aspnet-main/repositories/implementations/ClienteRepository.cs
+++ b/ZapAgenda-api-aspnet-main/repositories/implementations/ClienteRepository.cs
@@ -82,5 +82,15 @@ namespace ZapAgenda_api_aspnet.repositories.implementations
             }
             return Result.Ok(cliente);
         }
+
+        public async Task<Result<Cliente>> GetByCpfAsync(string cpf, Guid IdEmpresa)
+        {
+            var cliente = await _context.Cliente.FirstOrDefaultAsync(c => c.Cpf == cpf && c.IdEmpresa == IdEmpresa);
+            if (cliente == null)
+            {
+                return Result.Fail($"Não existe cliente de cpf: {cpf}");
+            }
+            return Result.Ok(cliente);
+        }
     }
 }

--- a/ZapAgenda-api-aspnet-main/repositories/interfaces/IClienteRepository.cs
+++ b/ZapAgenda-api-aspnet-main/repositories/interfaces/IClienteRepository.cs
@@ -10,6 +10,7 @@ namespace ZapAgenda_api_aspnet.repositories.interfaces
         Task<Result<Cliente>> CreateAsync(Cliente cliente, Guid IdEmpresa);
         Task<List<ClienteDto>>? GetAllPorEmpresaAsync(Guid IdEmpresa);
         Task<Result<Cliente>> GetById(int IdCliente, Guid Idempresa);
+        Task<Result<Cliente>> GetByCpfAsync(string cpf, Guid IdEmpresa);
         Task<Result<Cliente>> UpdateAsync(UpdateClienteDto updateClienteDto, int IdCliente, Guid IdEmpresa);
     }
 }

--- a/bot/config.js
+++ b/bot/config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  apiBaseUrl: process.env.API_BASE_URL || 'http://localhost:3000',
+  apiBaseUrl: process.env.API_BASE_URL || 'http://localhost:8080',
   companyId: process.env.COMPANY_ID || '00000000-0000-0000-0000-000000000000',
   // Update with the phone numbers (digits only) that the bot should respond to
   allowedNumbers: [


### PR DESCRIPTION
## Summary
- allow API to fetch client by CPF or list all clients
- default bot config to API port 8080

## Testing
- `npm test`
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ca4708748321bb1e3da59a55bffe