### PR TITLE
Fix client lookup HTTP method

### DIFF
--- a/bot/flows/registration.js
+++ b/bot/flows/registration.js
@@ -29,7 +29,10 @@ module.exports = {
     }
     session.cpf = text.replace(/\D/g, '');
     try {
-      const resp = await axios.get(`${apiBaseUrl}/${companyId}/cliente?cpf=${session.cpf}`);
+      const resp = await axios.post(
+        `${apiBaseUrl}/${companyId}/cliente/buscar`,
+        { cpf: session.cpf }
+      );
       if (resp.data && resp.data.length > 0) {
         session.client = resp.data[0];
         session.step = 'mainMenu';
@@ -65,7 +68,10 @@ module.exports = {
     const [firstName, ...rest] = text.split(' ');
     const lastName = rest.join(' ');
     try {
-      const existing = await axios.get(`${apiBaseUrl}/${companyId}/cliente?cpf=${session.cpf}`);
+      const existing = await axios.post(
+        `${apiBaseUrl}/${companyId}/cliente/buscar`,
+        { cpf: session.cpf }
+      );
       if (!existing.data || existing.data.length === 0) {
         const phone = msg.from.split('@')[0];
         const created = await axios.post(`${apiBaseUrl}/${companyId}/cliente`, {


### PR DESCRIPTION
## Summary
- Use POST endpoint for searching clients by CPF to avoid 405 errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c72d8292048321bad96bdc71e27668