### PR TITLE
Fix client lookup endpoint and update bot handling

### DIFF
--- a/ZapAgenda-api-aspnet-main/controllers/ClienteController.cs
+++ b/ZapAgenda-api-aspnet-main/controllers/ClienteController.cs
@@ -5,7 +5,8 @@ using ZapAgenda_api_aspnet.repositories.interfaces;
 
 namespace ZapAgenda_api_aspnet.controllers
 {
-    [Route("{IdEmpresa}/cliente")]
+    [Route("{IdEmpresa:guid}/cliente")]
+    [ApiController]
     public class ClienteController : ControllerBase
     {
         private readonly IClienteRepository _clienteRepo;
@@ -18,7 +19,7 @@ namespace ZapAgenda_api_aspnet.controllers
 
 
         [HttpGet]
-        public async Task<IActionResult> Get([FromQuery] string? cpf, Guid IdEmpresa)
+        public async Task<IActionResult> Get([FromQuery] string? cpf, [FromRoute] Guid IdEmpresa)
         {
             var empresa = await _empresaRepo.GetByGuidAsync(IdEmpresa);
             if (empresa.IsFailed)
@@ -35,7 +36,7 @@ namespace ZapAgenda_api_aspnet.controllers
             var cliente = await _clienteRepo.GetByCpfAsync(cpf, IdEmpresa);
             if (cliente.IsFailed)
             {
-                return BadRequest(cliente.Errors);
+                return NotFound(cliente.Errors);
             }
 
             return Ok(new[] { cliente.Value });
@@ -43,7 +44,7 @@ namespace ZapAgenda_api_aspnet.controllers
 
 
         [HttpGet("{idCliente}")]
-        public async Task<IActionResult> GetById([FromRoute] int idCliente, Guid IdEmpresa)
+        public async Task<IActionResult> GetById([FromRoute] int idCliente, [FromRoute] Guid IdEmpresa)
         {
 
             var empresa = await _empresaRepo.GetByGuidAsync(IdEmpresa);
@@ -66,7 +67,7 @@ namespace ZapAgenda_api_aspnet.controllers
         }
 
         [HttpPost]
-        public async Task<IActionResult> Create([FromBody] CreateClienteDto createClienteDto, Guid IdEmpresa)
+        public async Task<IActionResult> Create([FromBody] CreateClienteDto createClienteDto, [FromRoute] Guid IdEmpresa)
         {
             if (!ModelState.IsValid) { return BadRequest(ModelState); }
             var empresa = await _empresaRepo.GetByGuidAsync(IdEmpresa);
@@ -84,7 +85,7 @@ namespace ZapAgenda_api_aspnet.controllers
         }
 
         [HttpPut("{IdCliente}")]
-        public async Task<IActionResult> Update([FromBody] UpdateClienteDto updateClienteDto, [FromRoute] int IdCliente, Guid IdEmpresa)
+        public async Task<IActionResult> Update([FromBody] UpdateClienteDto updateClienteDto, [FromRoute] int IdCliente, [FromRoute] Guid IdEmpresa)
         {
             if (!ModelState.IsValid)
             {

--- a/bot/flows/registration.js
+++ b/bot/flows/registration.js
@@ -39,9 +39,9 @@ async function findClientByCPF(cpf) {
     return normalizeClient(resp.data);
   } catch (e) {
     const status = e?.response?.status;
-    // Seu controller retorna BadRequest (400) quando GetByCpfAsync falha — tratamos como "não achou".
-    if (status === 400) return null;
-    // 404 aqui indica empresa inválida (IdEmpresa não existe).
+    // Alguns backends retornam 400 quando o CPF não existe.
+    // 404 indica cliente inexistente ou empresa inválida.
+    if (status === 400 || status === 404) return null;
     throw e;
   }
 }


### PR DESCRIPTION
## Summary
- Add API controller annotations and proper 404 responses for client lookup
- Handle 404 responses in bot CPF lookup to allow new user registration

## Testing
- `cd ZapAgenda-api-aspnet-main && dotnet test` *(fails: command not found)*
- `cd bot && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c738659e4083218268607aad66d54b