### PR TITLE
feat: validate company config and drop bot docker

### DIFF
--- a/ZapAgenda-api-aspnet-main/Program.cs
+++ b/ZapAgenda-api-aspnet-main/Program.cs
@@ -26,7 +26,10 @@ builder.Services.AddCors(options =>
                .AllowAnyHeader());
 });
 
-builder.Services.AddControllers();
+builder.Services.AddControllers().AddNewtonsoftJson(options =>
+{
+    options.SerializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore;
+});
 builder.Services.AddEndpointsApiExplorer();
 
 builder.Services.AddSwaggerGen(c =>
@@ -58,11 +61,6 @@ builder.Services.AddSwaggerGen(c =>
     });
 });
 
-builder.Services.AddControllers().AddNewtonsoftJson(options =>
-{
-    options.SerializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore;
-});
-
 builder.Services.AddDbContext<CoreDBContext>(options =>
 {
     options.UseMySql(Environment.GetEnvironmentVariable("DEFAULT_CONNECTION_STRING"), new MySqlServerVersion(new Version(8, 0, 32)));
@@ -83,10 +81,6 @@ builder.Services.AddScoped<IAgendamentoRepository, AgendamentoRepository>();
 
 var app = builder.Build();
 
-app.UseCors("AllowMyOrigin");
-
-app.UseMiddleware<CustomExceptionMiddleware>();
-
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
@@ -98,10 +92,11 @@ else
     app.UseHttpsRedirection();
 }
 
+app.UseRouting();
+app.UseCors("AllowMyOrigin");
+app.UseMiddleware<CustomExceptionMiddleware>();
 app.UseAuthentication();
 app.UseAuthorization();
-
-
 
 app.MapControllers();
 

--- a/bot/config.js
+++ b/bot/config.js
@@ -1,8 +1,19 @@
+const GUID_REGEX = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+const {
+  API_BASE_URL = 'http://localhost:8080',
+  COMPANY_ID: RAW_COMPANY_ID,
+  ALLOWED_NUMBERS = ''
+} = process.env;
+
+const COMPANY_ID = (RAW_COMPANY_ID || '').trim();
+if (!COMPANY_ID || COMPANY_ID === '00000000-0000-0000-0000-000000000000' || !GUID_REGEX.test(COMPANY_ID)) {
+  throw new Error('COMPANY_ID inválido');
+}
+
 module.exports = {
-  apiBaseUrl: process.env.API_BASE_URL || 'http://localhost:8080',
-  companyId: process.env.COMPANY_ID || '00000000-0000-0000-0000-000000000000',
-  // Update with the phone numbers (digits only) that the bot should respond to
-  allowedNumbers: [
-    process.env.ALLOWED_NUMBER || '554598406778'
-  ]
+  apiBaseUrl: API_BASE_URL,
+  companyId: COMPANY_ID,
+  // Accept comma-separated list of numbers
+  allowedNumbers: ALLOWED_NUMBERS.split(',').map(n => n.trim()).filter(Boolean)
 };


### PR DESCRIPTION
## Summary
- enforce trimmed `COMPANY_ID` from environment and parse comma-separated allowed numbers
- route registration flow through `/cliente/by-cpf` with friendly error handling
- remove Dockerfile and compose file so the bot runs without Docker

## Testing
- `npm test`
- `dotnet clean ZapAgenda-api-aspnet-main/ZapAgenda-api-aspnet.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c740b71c908321aef1da5eed61199f