### PR TITLE
Fix appointment confirmation IDs and client CPF lookup

### DIFF
--- a/bot/flows/appointment.js
+++ b/bot/flows/appointment.js
@@ -31,7 +31,11 @@ function normalizeList(maybeList) {
     try { maybeList = JSON.parse(maybeList); } catch { return []; }
   }
   if (Array.isArray(maybeList)) return maybeList;
-  if (maybeList && typeof maybeList === 'object') return Object.values(maybeList);
+  if (maybeList && typeof maybeList === 'object') {
+    if ('value' in maybeList) return normalizeList(maybeList.value);
+    if ('data' in maybeList) return normalizeList(maybeList.data);
+    return Object.values(maybeList);
+  }
   return [];
 }
 
@@ -271,9 +275,23 @@ module.exports = {
         return;
       }
 
-      const idCliente = session.client?.id ?? session.client?.IdCliente ?? session.client?.Id;
-      const idUsuario = session.professional?.id ?? session.professional?.IdUsuario ?? session.professional?.Id;
-      const idServico = session.service?.id ?? session.service?.IdServico ?? session.service?.Id;
+      const idCliente =
+        session.client?.id ??
+        session.client?.idCliente ??
+        session.client?.IdCliente ??
+        session.client?.Id;
+
+      const idUsuario =
+        session.professional?.id ??
+        session.professional?.idUsuario ??
+        session.professional?.IdUsuario ??
+        session.professional?.Id;
+
+      const idServico =
+        session.service?.id ??
+        session.service?.idServico ??
+        session.service?.IdServico ??
+        session.service?.Id;
 
       if (!idCliente || !idUsuario || !idServico) {
         console.error('[appointment.confirm] missing ids', { idCliente, idUsuario, idServico });

--- a/bot/flows/registration.js
+++ b/bot/flows/registration.js
@@ -27,6 +27,11 @@ function sanitizeCPF(text) {
 function normalizeClient(data) {
   if (!data) return null;
   if (Array.isArray(data)) return data[0] || null;
+  if (typeof data === 'object' && 'value' in data) {
+    const v = data.value;
+    if (Array.isArray(v)) return v[0] || null;
+    return v;
+  }
   return data;
 }
 


### PR DESCRIPTION
## Summary
- handle wrapped API lists and capture IDs in various casing
- improve existing-client CPF search

## Testing
- `cd bot && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c754bc4f40832195ed8783743d26fe