### PR TITLE
Ensure CPF lookup sanitizes input

### DIFF
--- a/bot/flows/registration.js
+++ b/bot/flows/registration.js
@@ -39,12 +39,15 @@ function normalizeClient(data) {
 async function findClientByCPF(cpf) {
   const url = joinUrl(apiBaseUrl, companyId, 'cliente', 'by-cpf');
   try {
-    const resp = await axios.get(url, { params: { cpf } });
+    // Garante que o CPF enviado esteja apenas com números
+    const clean = sanitizeCPF(cpf);
+    const resp = await axios.get(url, { params: { cpf: clean } });
     return normalizeClient(resp.data);
   } catch (e) {
     const status = e?.response?.status;
-    if (status === 400) return null; // trata "não achou" como null
-    throw e; // 404 geralmente é empresa inválida
+    // Quando o backend retorna 400 ou 404 significa que o CPF não foi localizado
+    if (status === 400 || status === 404) return null;
+    throw e; // outros códigos de status devem ser tratados pelo chamador
   }
 }
 


### PR DESCRIPTION
## Summary
- sanitize CPF before checking existing user
- treat 400/404 responses as missing CPF lookup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c757afe33c83219a4aaafc6289eb3d