### PR TITLE
Fix backend to use default company id

### DIFF
--- a/ZapAgenda-api-aspnet-main/controllers/AgendamentoController.cs
+++ b/ZapAgenda-api-aspnet-main/controllers/AgendamentoController.cs
@@ -6,10 +6,11 @@ using Microsoft.AspNetCore.Mvc;
 using ZapAgenda_api_aspnet.Dtos.Agendamento;
 using ZapAgenda_api_aspnet.models;
 using ZapAgenda_api_aspnet.repositories.interfaces;
+using ZapAgenda_api_aspnet.helpers;
 
 namespace ZapAgenda_api_aspnet.controllers
 {
-    [Route("{IdEmpresa}/agendamento")]
+    [Route("agendamento")]
     public class AgendamentoController : ControllerBase
     {
         private readonly IAgendamentoRepository _agendamentoRepo;
@@ -19,13 +20,13 @@ namespace ZapAgenda_api_aspnet.controllers
         }
 
         [HttpPost]
-        public async Task<IActionResult> Create([FromBody] CreateAgendamentoDto createAgendamentoDto, Guid IdEmpresa)
+        public async Task<IActionResult> Create([FromBody] CreateAgendamentoDto createAgendamentoDto)
         {
             if (!ModelState.IsValid)
             {
                 return BadRequest(ModelState);
             }
-            var agendamento = await _agendamentoRepo.CreateAsync(createAgendamentoDto, IdEmpresa);
+            var agendamento = await _agendamentoRepo.CreateAsync(createAgendamentoDto, EmpresaConfig.DefaultId);
             if (agendamento.IsFailed)
             {
                 return BadRequest(agendamento.Errors);
@@ -34,9 +35,9 @@ namespace ZapAgenda_api_aspnet.controllers
 
         }
         [HttpGet("{IdAgendamento}")]
-        public async Task<IActionResult> GetById([FromRoute] int IdAgendamento, Guid IdEmpresa)
+        public async Task<IActionResult> GetById([FromRoute] int IdAgendamento)
         {
-            var agendamento = await _agendamentoRepo.GetById(IdAgendamento, IdEmpresa);
+            var agendamento = await _agendamentoRepo.GetById(IdAgendamento, EmpresaConfig.DefaultId);
             if (agendamento.IsFailed)
             {
                 return BadRequest(agendamento.Errors);
@@ -45,10 +46,10 @@ namespace ZapAgenda_api_aspnet.controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> GetAllByIdEmpresa(Guid IdEmpresa)
+        public async Task<IActionResult> GetAllByIdEmpresa()
         {
 
-            var agendamento = await _agendamentoRepo.GetAllByEmpresa(IdEmpresa);
+            var agendamento = await _agendamentoRepo.GetAllByEmpresa(EmpresaConfig.DefaultId);
             if(agendamento.IsFailed) {
                 return NotFound(agendamento.Errors);
             }
@@ -56,12 +57,12 @@ namespace ZapAgenda_api_aspnet.controllers
         }
 
         [HttpPut("{IdAgendamento}")]
-        public async Task<IActionResult> Update([FromBody] UpdateAgendamentoDto updateAgendamentoDto,[FromRoute] int IdAgendamento,Guid IdEmpresa) {
+        public async Task<IActionResult> Update([FromBody] UpdateAgendamentoDto updateAgendamentoDto,[FromRoute] int IdAgendamento) {
             if(!ModelState.IsValid) {
                 return BadRequest(ModelState);
             }
 
-            var result = await _agendamentoRepo.UpdateAsync(updateAgendamentoDto,IdAgendamento,IdEmpresa);
+            var result = await _agendamentoRepo.UpdateAsync(updateAgendamentoDto,IdAgendamento,EmpresaConfig.DefaultId);
             if(result.IsFailed) {
                 return BadRequest(result.Errors);
             }

--- a/ZapAgenda-api-aspnet-main/controllers/AuthController.cs
+++ b/ZapAgenda-api-aspnet-main/controllers/AuthController.cs
@@ -3,10 +3,11 @@ using ZapAgenda_api_aspnet.Dtos.Usuario;
 using ZapAgenda_api_aspnet.models;
 using ZapAgenda_api_aspnet.repositories.interfaces;
 using ZapAgenda_api_aspnet.services.interfaces;
+using ZapAgenda_api_aspnet.helpers;
 
 namespace ZapAgenda_api_aspnet.controllers
 {
-    [Route("{IdEmpresa}/autentificacao")]
+    [Route("autentificacao")]
     public class AuthController : ControllerBase
     {
         private readonly IConfiguration _configuration;
@@ -21,8 +22,9 @@ namespace ZapAgenda_api_aspnet.controllers
             _tokenService = tokenService;
         }
         [HttpPost]
-        public async Task<IActionResult> Login([FromBody] LoginDto loginDto, Guid IdEmpresa)
+        public async Task<IActionResult> Login([FromBody] LoginDto loginDto)
         {
+            var IdEmpresa = EmpresaConfig.DefaultId;
             var usuario = await _usuarioRepo.GetUsariosByEmpresaAndNomeUsuario(IdEmpresa, loginDto.NomeUsuario);
             if (usuario.IsFailed)
             {

--- a/ZapAgenda-api-aspnet-main/controllers/ClienteController.cs
+++ b/ZapAgenda-api-aspnet-main/controllers/ClienteController.cs
@@ -2,11 +2,12 @@ using Microsoft.AspNetCore.Mvc;
 using ZapAgenda_api_aspnet.Dtos.Cliente;
 using ZapAgenda_api_aspnet.Mappers;
 using ZapAgenda_api_aspnet.repositories.interfaces;
+using ZapAgenda_api_aspnet.helpers;
 
 namespace ZapAgenda_api_aspnet.controllers
 {
     [ApiController]
-    [Route("{IdEmpresa:guid}/cliente")]
+    [Route("cliente")]
     public class ClienteController : ControllerBase
     {
         private readonly IClienteRepository _clienteRepo;
@@ -20,8 +21,9 @@ namespace ZapAgenda_api_aspnet.controllers
 
         // Lista todos os clientes da empresa
         [HttpGet]
-        public async Task<IActionResult> GetAll([FromRoute] Guid IdEmpresa)
+        public async Task<IActionResult> GetAll()
         {
+            var IdEmpresa = EmpresaConfig.DefaultId;
             var empresa = await _empresaRepo.GetByGuidAsync(IdEmpresa);
             if (empresa.IsFailed) return NotFound(empresa.Errors);
 
@@ -31,11 +33,12 @@ namespace ZapAgenda_api_aspnet.controllers
 
         // Consulta por CPF (rota dedicada)
         [HttpGet("by-cpf")]
-        public async Task<IActionResult> GetByCpf([FromQuery] string cpf, [FromRoute] Guid IdEmpresa)
+        public async Task<IActionResult> GetByCpf([FromQuery] string cpf)
         {
             if (string.IsNullOrWhiteSpace(cpf))
                 return BadRequest("CPF obrigatório.");
 
+            var IdEmpresa = EmpresaConfig.DefaultId;
             var empresa = await _empresaRepo.GetByGuidAsync(IdEmpresa);
             if (empresa.IsFailed) return NotFound(empresa.Errors);
 
@@ -47,8 +50,9 @@ namespace ZapAgenda_api_aspnet.controllers
 
         // Busca por ID
         [HttpGet("{idCliente:int}")]
-        public async Task<IActionResult> GetById([FromRoute] int idCliente, [FromRoute] Guid IdEmpresa)
+        public async Task<IActionResult> GetById([FromRoute] int idCliente)
         {
+            var IdEmpresa = EmpresaConfig.DefaultId;
             var empresa = await _empresaRepo.GetByGuidAsync(IdEmpresa);
             if (empresa.IsFailed) return NotFound(empresa.Errors);
 
@@ -61,10 +65,11 @@ namespace ZapAgenda_api_aspnet.controllers
 
         // Criação
         [HttpPost]
-        public async Task<IActionResult> Create([FromBody] CreateClienteDto createClienteDto, [FromRoute] Guid IdEmpresa)
+        public async Task<IActionResult> Create([FromBody] CreateClienteDto createClienteDto)
         {
             if (!ModelState.IsValid) return BadRequest(ModelState);
 
+            var IdEmpresa = EmpresaConfig.DefaultId;
             var empresa = await _empresaRepo.GetByGuidAsync(IdEmpresa);
             if (empresa.IsFailed) return NotFound(empresa.Errors);
 
@@ -72,15 +77,16 @@ namespace ZapAgenda_api_aspnet.controllers
             var result = await _clienteRepo.CreateAsync(cliente, IdEmpresa);
             if (result.IsFailed) return BadRequest(result.Errors);
 
-            return CreatedAtAction(nameof(GetById), new { idCliente = cliente.Id, IdEmpresa }, cliente);
+            return CreatedAtAction(nameof(GetById), new { idCliente = cliente.Id }, cliente);
         }
 
         // Atualização
         [HttpPut("{IdCliente:int}")]
-        public async Task<IActionResult> Update([FromBody] UpdateClienteDto updateClienteDto, [FromRoute] int IdCliente, [FromRoute] Guid IdEmpresa)
+        public async Task<IActionResult> Update([FromBody] UpdateClienteDto updateClienteDto, [FromRoute] int IdCliente)
         {
             if (!ModelState.IsValid) return BadRequest(ModelState);
 
+            var IdEmpresa = EmpresaConfig.DefaultId;
             var empresa = await _empresaRepo.GetByGuidAsync(IdEmpresa);
             if (empresa.IsFailed) return BadRequest("Empresa não existe");
 

--- a/ZapAgenda-api-aspnet-main/controllers/ServicoController.cs
+++ b/ZapAgenda-api-aspnet-main/controllers/ServicoController.cs
@@ -2,10 +2,11 @@ using Microsoft.AspNetCore.Mvc;
 using ZapAgenda_api_aspnet.Dtos.Servico;
 using ZapAgenda_api_aspnet.Mappers;
 using ZapAgenda_api_aspnet.repositories.interfaces;
+using ZapAgenda_api_aspnet.helpers;
 
 namespace ZapAgenda_api_aspnet.controllers
 {
-    [Route("{IdEmpresa}/servico")]
+    [Route("servico")]
     public class ServicoController : ControllerBase
     {
         private readonly IServicoRepository _servicoRepo;
@@ -15,9 +16,9 @@ namespace ZapAgenda_api_aspnet.controllers
         }
 
         [HttpGet("{IdServico}")]
-        public async Task<IActionResult> GetById([FromRoute] int IdServico, Guid IdEmpresa)
+        public async Task<IActionResult> GetById([FromRoute] int IdServico)
         {
-            var servico = await _servicoRepo.GetById(IdServico, IdEmpresa);
+            var servico = await _servicoRepo.GetById(IdServico, EmpresaConfig.DefaultId);
             if (servico.IsFailed)
             {
                 return BadRequest(servico.Errors);
@@ -26,9 +27,9 @@ namespace ZapAgenda_api_aspnet.controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> GetAllByIdEmpresa(Guid IdEmpresa)
+        public async Task<IActionResult> GetAllByIdEmpresa()
         {
-            var servicos = await _servicoRepo.GetAllByEmpresa(IdEmpresa);
+            var servicos = await _servicoRepo.GetAllByEmpresa(EmpresaConfig.DefaultId);
             if (servicos.IsFailed)
             {
                 return BadRequest(servicos.Errors);
@@ -38,29 +39,29 @@ namespace ZapAgenda_api_aspnet.controllers
 
         //todo:ver pq não retorna o objeto da empresa
         [HttpPost]
-        public async Task<IActionResult> Create([FromBody] CreateServicoDto createServicoDto, Guid IdEmpresa)
+        public async Task<IActionResult> Create([FromBody] CreateServicoDto createServicoDto)
         {
             if (!ModelState.IsValid)
             {
                 return BadRequest(ModelState);
             }
             var servico = createServicoDto.ToCreateServicoDto();
-            var result = await _servicoRepo.CreateAsync(servico, IdEmpresa);
+            var result = await _servicoRepo.CreateAsync(servico, EmpresaConfig.DefaultId);
             if (result.IsFailed)
             {
                 return BadRequest(result.Errors);
             }
-            return CreatedAtAction(nameof(GetById), new { idServico = servico.Id, IdEmpresa = IdEmpresa }, servico);
+            return CreatedAtAction(nameof(GetById), new { idServico = servico.Id }, servico);
         }
 
         [HttpPut("{idServico}")]
-        public async Task<IActionResult> Update([FromBody] UpdateServicoDto updateServicoDto, [FromRoute] int idServico, Guid IdEmpresa)
+        public async Task<IActionResult> Update([FromBody] UpdateServicoDto updateServicoDto, [FromRoute] int idServico)
         {
             if (!ModelState.IsValid)
             {
                 return BadRequest(ModelState);
             }
-            var result = await _servicoRepo.UpdateAsync(updateServicoDto, idServico, IdEmpresa);
+            var result = await _servicoRepo.UpdateAsync(updateServicoDto, idServico, EmpresaConfig.DefaultId);
             if (result.IsFailed)
             {
                 return BadRequest(result.Errors);

--- a/ZapAgenda-api-aspnet-main/controllers/UsuarioController.cs
+++ b/ZapAgenda-api-aspnet-main/controllers/UsuarioController.cs
@@ -3,10 +3,11 @@ using Microsoft.AspNetCore.Mvc;
 using ZapAgenda_api_aspnet.Dtos.Usuario;
 using ZapAgenda_api_aspnet.Mappers;
 using ZapAgenda_api_aspnet.repositories.interfaces;
+using ZapAgenda_api_aspnet.helpers;
 
 namespace ZapAgenda_api_aspnet.controllers
 {
-    [Route("{IdEmpresa}/usuario")]
+    [Route("usuario")]
     public class UsuarioController : ControllerBase
     {
         private readonly IUsuarioRepository _usuarioRepo;
@@ -19,8 +20,9 @@ namespace ZapAgenda_api_aspnet.controllers
 
         //[Authorize]
         [HttpGet("{idUsuario:int}")]
-        public async Task<IActionResult> GetById([FromRoute] int idUsuario, Guid IdEmpresa)
+        public async Task<IActionResult> GetById([FromRoute] int idUsuario)
         {
+            var IdEmpresa = EmpresaConfig.DefaultId;
             if (await _empresaRepo.GetByGuidAsync(IdEmpresa) == null)
             {
                 return NotFound($"Não existe empresa com ID {IdEmpresa}.");
@@ -41,12 +43,13 @@ namespace ZapAgenda_api_aspnet.controllers
 
         //[Authorize]
         [HttpPost]
-        public async Task<IActionResult> Create([FromBody] CreateUsuarioDto createUsuarioDto, Guid IdEmpresa)
+        public async Task<IActionResult> Create([FromBody] CreateUsuarioDto createUsuarioDto)
         {
             if (!ModelState.IsValid)
             {
                 return BadRequest(ModelState);
             }
+            var IdEmpresa = EmpresaConfig.DefaultId;
             if (await _empresaRepo.GetByGuidAsync(IdEmpresa) == null)
             {
                 return NotFound($"Não existe empresa com ID {IdEmpresa}.");
@@ -58,14 +61,14 @@ namespace ZapAgenda_api_aspnet.controllers
             {
                 return BadRequest(new { Erros = result.Errors.Select(e => e.Message) });
             }
-            return CreatedAtAction(nameof(GetById), new { idUsuario = usuario.Id, IdEmpresa = IdEmpresa }, usuario);
+            return CreatedAtAction(nameof(GetById), new { idUsuario = usuario.Id }, usuario);
         }
 
         //[Authorize]
         [HttpGet]
-        public async Task<IActionResult> GetAllByIdEmpresa(Guid IdEmpresa)
+        public async Task<IActionResult> GetAllByIdEmpresa()
         {
-            var usuarios = await _usuarioRepo.GetUsuariosByEmpresa(IdEmpresa);
+            var usuarios = await _usuarioRepo.GetUsuariosByEmpresa(EmpresaConfig.DefaultId);
             if (!usuarios.IsSuccess)
             {
                 return NotFound(new { message = usuarios.Errors });
@@ -74,9 +77,9 @@ namespace ZapAgenda_api_aspnet.controllers
         }
 
         [HttpGet("opcoes-filtro")]
-        public async Task<IActionResult> GetAllByEmpresaParaFiltro(Guid IdEmpresa)
+        public async Task<IActionResult> GetAllByEmpresaParaFiltro()
         {
-            var usuarios = await _usuarioRepo.GetNomeUsuarioDto(IdEmpresa);
+            var usuarios = await _usuarioRepo.GetNomeUsuarioDto(EmpresaConfig.DefaultId);
             if (usuarios.IsFailed)
             {
                 return BadRequest(usuarios.Errors);
@@ -86,7 +89,7 @@ namespace ZapAgenda_api_aspnet.controllers
 
         [Authorize]
         [HttpPut("{idUsuario:int}")]
-        public async Task<IActionResult> UpdateUsuario([FromBody] UpdateUsuarioDto updateUsuarioDto, [FromRoute] int idUsuario, Guid IdEmpresa)
+        public async Task<IActionResult> UpdateUsuario([FromBody] UpdateUsuarioDto updateUsuarioDto, [FromRoute] int idUsuario)
         {
 
             if (!ModelState.IsValid)
@@ -94,6 +97,7 @@ namespace ZapAgenda_api_aspnet.controllers
                 return BadRequest(ModelState);
             }
 
+            var IdEmpresa = EmpresaConfig.DefaultId;
             if (await _empresaRepo.GetByGuidAsync(IdEmpresa) == null)
             {
                 return NotFound($"Não existe empresa de id{IdEmpresa}");
@@ -108,12 +112,13 @@ namespace ZapAgenda_api_aspnet.controllers
 
         [Authorize]
         [HttpPatch("{idUsuario:int}")]
-        public async Task<IActionResult> UpdateSenhaUsuario([FromBody] UpdateSenhaUsuarioDto updateSenhaUsuarioDto, [FromRoute] int idUsuario, Guid IdEmpresa)
+        public async Task<IActionResult> UpdateSenhaUsuario([FromBody] UpdateSenhaUsuarioDto updateSenhaUsuarioDto, [FromRoute] int idUsuario)
         {
             if (!ModelState.IsValid)
             {
                 return BadRequest(ModelState);
             }
+            var IdEmpresa = EmpresaConfig.DefaultId;
             if (await _empresaRepo.GetByGuidAsync(IdEmpresa) == null)
             {
                 return NotFound($"Não existe empresa de id{IdEmpresa}");

--- a/ZapAgenda-api-aspnet-main/helpers/EmpresaConfig.cs
+++ b/ZapAgenda-api-aspnet-main/helpers/EmpresaConfig.cs
@@ -1,0 +1,8 @@
+using System;
+namespace ZapAgenda_api_aspnet.helpers
+{
+    public static class EmpresaConfig
+    {
+        public static readonly Guid DefaultId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+    }
+}


### PR DESCRIPTION
## Summary
- hardcode EmpresaConfig.DefaultId for company `11111111-2222-3333-4444-555555555555`
- remove company id route parameters from controllers and use the default

## Testing
- `dotnet build ZapAgenda-api-aspnet-main/ZapAgenda-api-aspnet.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c760fb99b88321b05603946ad92540