### PR TITLE
Fix CPF lookup tenant usage

### DIFF
--- a/bot/config.js
+++ b/bot/config.js
@@ -1,9 +1,12 @@
 const GUID_REGEX = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
 require('dotenv').config();
 
+const DEFAULT_CPF_TENANT_ID = '11111111-2222-3333-4444-555555555555';
+
 const {
   API_BASE_URL = 'http://localhost:8080',
   COMPANY_ID: RAW_COMPANY_ID,
+  CPF_TENANT_ID: RAW_CPF_TENANT_ID,
   ALLOWED_NUMBERS = ''
 } = process.env;
 
@@ -12,9 +15,15 @@ if (!COMPANY_ID || COMPANY_ID === '00000000-0000-0000-0000-000000000000' || !GUI
   throw new Error('COMPANY_ID inválido');
 }
 
+const CPF_TENANT_ID = (RAW_CPF_TENANT_ID || DEFAULT_CPF_TENANT_ID).trim();
+if (!GUID_REGEX.test(CPF_TENANT_ID)) {
+  throw new Error('CPF_TENANT_ID inválido');
+}
+
 module.exports = {
   apiBaseUrl: API_BASE_URL,
   companyId: COMPANY_ID,
+  cpfTenantId: CPF_TENANT_ID,
   // Accept comma-separated list of numbers
   allowedNumbers: ALLOWED_NUMBERS.split(',').map(n => n.trim()).filter(Boolean)
 };

--- a/bot/flows/registration.js
+++ b/bot/flows/registration.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const axios = require('axios');
-const { apiBaseUrl, companyId } = require('../config');
+const { apiBaseUrl, companyId, cpfTenantId } = require('../config');
 const {
   menuText,
   startText,
@@ -35,11 +35,11 @@ function normalizeClient(data) {
   return data;
 }
 
-/** GET /{companyId}/cliente/by-cpf?cpf=... → objeto ou null */
+/** GET /{cpfTenantId}/cliente/by-cpf?cpf=... → objeto ou null */
 async function findClientByCPF(cpf) {
-  const url = joinUrl(apiBaseUrl, companyId, 'cliente', 'by-cpf');
+  const url = joinUrl(apiBaseUrl, cpfTenantId, 'cliente', 'by-cpf');
   const clean = sanitizeCPF(cpf);
-  console.log('[findClientByCPF] url:', url, 'cpf:', clean);
+  console.log('[findClientByCPF] url:', url, 'tenant:', cpfTenantId, 'cpf:', clean);
   try {
     // Garante que o CPF enviado esteja apenas com números
     const resp = await axios.get(url, { params: { cpf: clean } });


### PR DESCRIPTION
## Summary
- add configuration support for a dedicated CPF lookup tenant id with the default company guid
- build the CPF lookup URL using the configured tenant id so the correct company is queried

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68c9ef9e71588321a3d6f801b9973a51