### PR TITLE
Add greeting when matching existing client by CPF

### DIFF
--- a/bot/flows/conversation.js
+++ b/bot/flows/conversation.js
@@ -716,7 +716,14 @@ async function awaitExistingCPF(session, msg, text, sessions) {
     if (client) {
       session.tempClient = client;
       session.step = 'confirmClient';
-      await msg.reply(`Encontramos seu cadastro: ${client.nome}.\n1 - Sim, sou eu\n0 - Voltar`);
+      const clientName =
+        getProp(client, 'nome', 'nomeInteiro', 'nomeCompleto', 'nomeCliente', 'Nome', 'NomeCompleto', 'NomeCliente') ||
+        'cliente';
+      const trimmedName = String(clientName).trim();
+      const greetingName = trimmedName.length ? trimmedName : 'cliente';
+      await msg.reply(
+        `Olá ${greetingName}! Encontramos seu cadastro.\n1 - Sim, sou eu\n0 - Voltar`
+      );
     } else {
       session.step = 'awaitCPF';
       await msg.reply(


### PR DESCRIPTION
## Summary
- greet returning users by name after locating their CPF
- keep the confirmation flow unchanged so the existing registration is reused for scheduling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb29400e248321bcca9bd5aabbd301